### PR TITLE
feat: add --web.forward-headers to forward extra request headers to Prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ The MCP server supports [Prometheus Web Configuration files](https://github.com/
 Use the `--web.config.file` command-line flag to provide an HTTP configuration file.
 Please see [Flags](#command-line-flags) for more information.
 
+### Per-Request Header Forwarding (HTTP transport)
+
+When running with the HTTP transport, the `Authorization` header of each incoming MCP request is forwarded to the Prometheus API, so callers can bring their own credentials instead of (or in addition to) the server-level `--http.config` credentials.
+Additional request headers can be forwarded with the repeatable `--web.forward-headers` flag — for example `--web.forward-headers=X-Scope-OrgID` lets each caller select a tenant on multi-tenant Prometheus-compatible backends (Cortex, Mimir, Thanos).
+Requests that carry none of the forwarded headers fall back to the default client built from `--http.config`.
+
 ## Telemetry
 ### Metrics
 
@@ -478,6 +484,15 @@ Flags:
       --web.max-requests=40      Maximum number of parallel scrape
                                  requests. Use 0 to disable.
                                  ($PROMETHEUS_MCP_SERVER_WEB_MAX_REQUESTS)
+      --web.forward-headers=WEB.FORWARD-HEADERS ...  
+                                 Name of an additional HTTP request header
+                                 to forward from incoming MCP requests to the
+                                 Prometheus API (HTTP transport only; repeat the
+                                 flag for multiple headers). The Authorization
+                                 header is always forwarded. Useful for
+                                 multi-tenant Prometheus-compatible backends,
+                                 e.g. `X-Scope-OrgID` for Cortex/Mimir/Thanos.
+                                 ($PROMETHEUS_MCP_WEB_FORWARD_HEADERS)
       --[no-]dangerous.enable-tsdb-admin-tools  
                                  Enable and allow using tools that access
                                  Prometheus' TSDB Admin API endpoints

--- a/cmd/prometheus-mcp/main.go
+++ b/cmd/prometheus-mcp/main.go
@@ -121,6 +121,14 @@ var (
 		"Maximum number of parallel scrape requests. Use 0 to disable.",
 	).Default("40").Int()
 
+	flagWebForwardHeaders = kingpin.Flag(
+		"web.forward-headers",
+		"Name of an additional HTTP request header to forward from incoming MCP requests"+
+			" to the Prometheus API (HTTP transport only; repeat the flag for multiple headers)."+
+			" The Authorization header is always forwarded. Useful for multi-tenant"+
+			" Prometheus-compatible backends, e.g. `X-Scope-OrgID` for Cortex/Mimir/Thanos.",
+	).Strings()
+
 	flagEnableTsdbAdminTools = kingpin.Flag(
 		"dangerous.enable-tsdb-admin-tools",
 		"Enable and allow using tools that access Prometheus' TSDB Admin API endpoints"+
@@ -296,7 +304,7 @@ func main() {
 				case "http":
 					logger.Debug("starting MCP server", "transport", "http")
 
-					httpMcpHandler := mcp.NewStreamableHTTPHandler(mcpServer, logger, *flagMcpSessionTimeout)
+					httpMcpHandler := mcp.NewStreamableHTTPHandler(mcpServer, logger, *flagMcpSessionTimeout, *flagWebForwardHeaders...)
 					http.Handle("/mcp", httpMcpHandler)
 					<-cancel
 				default:

--- a/pkg/mcp/middleware_test.go
+++ b/pkg/mcp/middleware_test.go
@@ -981,3 +981,214 @@ func TestAuthContextMiddleware_Integration(t *testing.T) {
 		require.Equal(t, requestBody, capturedBody)
 	})
 }
+
+// TestForwardedHeadersContext tests storing and retrieving forwarded headers
+// from a context.
+func TestForwardedHeadersContext(t *testing.T) {
+	t.Parallel()
+
+	t.Run("stores and retrieves headers", func(t *testing.T) {
+		t.Parallel()
+
+		headers := http.Header{}
+		headers.Set("X-Scope-Orgid", "tenant-a")
+
+		ctx := addForwardedHeadersToContext(context.Background(), headers)
+		got := getForwardedHeadersFromContext(ctx)
+		require.Equal(t, "tenant-a", got.Get("X-Scope-OrgID"))
+	})
+
+	t.Run("returns nil for context without headers", func(t *testing.T) {
+		t.Parallel()
+
+		require.Nil(t, getForwardedHeadersFromContext(context.Background()))
+	})
+}
+
+// TestAuthContextMiddleware_ForwardHeaders tests that the middleware captures
+// additional configured headers into the request context.
+func TestAuthContextMiddleware_ForwardHeaders(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name            string
+		forwardHeaders  []string
+		requestHeaders  map[string][]string
+		expectedHeaders map[string][]string
+		expectNil       bool
+	}{
+		{
+			name:            "captures configured header",
+			forwardHeaders:  []string{"X-Scope-OrgID"},
+			requestHeaders:  map[string][]string{"X-Scope-OrgID": {"tenant-a"}},
+			expectedHeaders: map[string][]string{"X-Scope-OrgID": {"tenant-a"}},
+		},
+		{
+			name:            "preserves multiple values of a configured header",
+			forwardHeaders:  []string{"X-Scope-OrgID"},
+			requestHeaders:  map[string][]string{"X-Scope-OrgID": {"tenant-a", "tenant-b"}},
+			expectedHeaders: map[string][]string{"X-Scope-OrgID": {"tenant-a", "tenant-b"}},
+		},
+		{
+			name:           "ignores headers that are not configured",
+			forwardHeaders: []string{"X-Scope-OrgID"},
+			requestHeaders: map[string][]string{"X-Custom-Header": {"custom-value"}},
+			expectNil:      true,
+		},
+		{
+			name:           "captures nothing when no headers configured",
+			forwardHeaders: nil,
+			requestHeaders: map[string][]string{"X-Scope-OrgID": {"tenant-a"}},
+			expectNil:      true,
+		},
+		{
+			name:           "captures multiple configured headers",
+			forwardHeaders: []string{"X-Scope-OrgID", "X-Request-ID"},
+			requestHeaders: map[string][]string{
+				"X-Scope-OrgID": {"tenant-a"},
+				"X-Request-ID":  {"req-123"},
+			},
+			expectedHeaders: map[string][]string{
+				"X-Scope-OrgID": {"tenant-a"},
+				"X-Request-ID":  {"req-123"},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var captured http.Header
+
+			innerHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				captured = getForwardedHeadersFromContext(r.Context())
+				w.WriteHeader(http.StatusOK)
+			})
+
+			middleware := authContextMiddleware(innerHandler, tc.forwardHeaders...)
+
+			req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+			for name, values := range tc.requestHeaders {
+				for _, v := range values {
+					req.Header.Add(name, v)
+				}
+			}
+
+			rr := httptest.NewRecorder()
+			middleware.ServeHTTP(rr, req)
+			require.Equal(t, http.StatusOK, rr.Code)
+
+			if tc.expectNil {
+				require.Nil(t, captured)
+				return
+			}
+			for name, values := range tc.expectedHeaders {
+				require.Equal(t, values, captured.Values(name))
+			}
+		})
+	}
+}
+
+// TestFullHeaderForwardingFlow tests that forwarded headers captured from an
+// incoming request reach the Prometheus backend, alongside Authorization.
+func TestFullHeaderForwardingFlow(t *testing.T) {
+	t.Parallel()
+
+	newCaptureServer := func(mu *sync.Mutex, auth, orgID *string) *httptest.Server {
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			mu.Lock()
+			*auth = r.Header.Get("Authorization")
+			*orgID = r.Header.Get("X-Scope-OrgID")
+			mu.Unlock()
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"status":"success","data":{"resultType":"vector","result":[]}}`))
+		}))
+	}
+
+	t.Run("forwarded header and auth both reach Prometheus", func(t *testing.T) {
+		t.Parallel()
+
+		var mu sync.Mutex
+		var receivedAuth, receivedOrgID string
+		promServer := newCaptureServer(&mu, &receivedAuth, &receivedOrgID)
+		defer promServer.Close()
+
+		container := newTestContainer(nil)
+		container.prometheusURL = promServer.URL
+		container.defaultRT = http.DefaultTransport
+
+		headers := http.Header{}
+		headers.Set("X-Scope-Orgid", "tenant-a")
+		ctx := addAuthToContext(context.Background(), "Bearer my-secret-api-token")
+		ctx = addForwardedHeadersToContext(ctx, headers)
+
+		_, rt := container.GetAPIClient(ctx)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, promServer.URL+"/api/v1/query", nil)
+		require.NoError(t, err)
+		_, err = rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Equal(t, "Bearer my-secret-api-token", receivedAuth)
+		require.Equal(t, "tenant-a", receivedOrgID)
+	})
+
+	t.Run("forwarded header reaches Prometheus without auth", func(t *testing.T) {
+		t.Parallel()
+
+		var mu sync.Mutex
+		var receivedAuth, receivedOrgID string
+		promServer := newCaptureServer(&mu, &receivedAuth, &receivedOrgID)
+		defer promServer.Close()
+
+		container := newTestContainer(nil)
+		container.prometheusURL = promServer.URL
+		container.defaultRT = http.DefaultTransport
+
+		headers := http.Header{}
+		headers.Set("X-Scope-Orgid", "tenant-b")
+		ctx := addForwardedHeadersToContext(context.Background(), headers)
+
+		_, rt := container.GetAPIClient(ctx)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, promServer.URL+"/api/v1/query", nil)
+		require.NoError(t, err)
+		_, err = rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Empty(t, receivedAuth)
+		require.Equal(t, "tenant-b", receivedOrgID)
+	})
+
+	t.Run("default client sends neither auth nor forwarded headers", func(t *testing.T) {
+		t.Parallel()
+
+		var mu sync.Mutex
+		var receivedAuth, receivedOrgID string
+		promServer := newCaptureServer(&mu, &receivedAuth, &receivedOrgID)
+		defer promServer.Close()
+
+		container := newTestContainer(nil)
+		container.prometheusURL = promServer.URL
+		container.defaultRT = http.DefaultTransport
+
+		ctx := context.Background()
+		_, rt := container.GetAPIClient(ctx)
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, promServer.URL+"/api/v1/query", nil)
+		require.NoError(t, err)
+		_, err = rt.RoundTrip(req)
+		require.NoError(t, err)
+
+		mu.Lock()
+		defer mu.Unlock()
+		require.Empty(t, receivedAuth)
+		require.Empty(t, receivedOrgID)
+	})
+}

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -230,8 +230,10 @@ func NewServer(ctx context.Context, cfg ServerConfig) (*mcp.Server, *ServerConta
 }
 
 // NewStreamableHTTPHandler creates an HTTP handler for the MCP server.
-// It wraps the handler with auth context middleware to forward Authorization headers.
-func NewStreamableHTTPHandler(server *mcp.Server, logger *slog.Logger, sessionTimeout time.Duration) http.Handler {
+// It wraps the handler with auth context middleware to forward Authorization
+// headers, plus any additional request headers named in forwardHeaders (e.g.
+// X-Scope-OrgID for multi-tenant Prometheus-compatible backends).
+func NewStreamableHTTPHandler(server *mcp.Server, logger *slog.Logger, sessionTimeout time.Duration, forwardHeaders ...string) http.Handler {
 	if sessionTimeout == 0 {
 		// 0 value for session timeout means that sessions never close.
 		// Set a default if unset.
@@ -249,7 +251,7 @@ func NewStreamableHTTPHandler(server *mcp.Server, logger *slog.Logger, sessionTi
 	)
 
 	// Wrap with auth context middleware
-	return authContextMiddleware(handler)
+	return authContextMiddleware(handler, forwardHeaders...)
 }
 
 // authHeaderKey is the context key for storing the Authorization header.
@@ -268,13 +270,40 @@ func getAuthFromContext(ctx context.Context) string {
 	return ""
 }
 
+// forwardedHeadersKey is the context key for storing additional forwarded headers.
+type forwardedHeadersKey struct{}
+
+// addForwardedHeadersToContext adds forwarded header values to the context.
+func addForwardedHeadersToContext(ctx context.Context, headers http.Header) context.Context {
+	return context.WithValue(ctx, forwardedHeadersKey{}, headers)
+}
+
+// getForwardedHeadersFromContext retrieves forwarded headers from the context.
+func getForwardedHeadersFromContext(ctx context.Context) http.Header {
+	if headers, ok := ctx.Value(forwardedHeadersKey{}).(http.Header); ok {
+		return headers
+	}
+	return nil
+}
+
 // authContextMiddleware creates an HTTP middleware that extracts the Authorization
-// header from requests and adds it to the request context.
-func authContextMiddleware(next http.Handler) http.Handler {
+// header from requests and adds it to the request context. Additional request
+// headers named in forwardHeaders are captured into the context as well, so
+// per-request API clients can forward them to the backend.
+func authContextMiddleware(next http.Handler, forwardHeaders ...string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		if auth := r.Header.Get("Authorization"); auth != "" {
 			ctx = addAuthToContext(ctx, auth)
+		}
+		forwarded := make(http.Header)
+		for _, name := range forwardHeaders {
+			for _, value := range r.Header.Values(name) {
+				forwarded.Add(name, value)
+			}
+		}
+		if len(forwarded) > 0 {
+			ctx = addForwardedHeadersToContext(ctx, forwarded)
 		}
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
@@ -345,12 +374,13 @@ func newServerContainer(cfg ServerConfig) (*ServerContainer, error) {
 }
 
 // GetAPIClient returns a Prometheus API client, optionally with auth from context.
-// If an Authorization header is present in the context, a new client with those
-// credentials is created. Otherwise, the default client is returned.
+// If an Authorization header or forwarded headers are present in the context, a
+// new client carrying them is created. Otherwise, the default client is returned.
 func (s *ServerContainer) GetAPIClient(ctx context.Context) (promv1.API, http.RoundTripper) {
 	auth := getAuthFromContext(ctx)
-	if auth != "" {
-		client, rt := s.createClientWithAuth(auth)
+	forwarded := getForwardedHeadersFromContext(ctx)
+	if auth != "" || len(forwarded) > 0 {
+		client, rt := s.createClientWithAuth(auth, forwarded)
 		if client != nil {
 			return client, rt
 		}
@@ -360,20 +390,47 @@ func (s *ServerContainer) GetAPIClient(ctx context.Context) (promv1.API, http.Ro
 	return s.defaultAPIClient, s.defaultRT
 }
 
-// createClientWithAuth creates a new API client with the given Authorization header.
-func (s *ServerContainer) createClientWithAuth(authorization string) (promv1.API, http.RoundTripper) {
-	var authType, secret string
-	if strings.Contains(authorization, " ") {
-		parts := strings.SplitN(authorization, " ", 2)
-		authType = parts[0]
-		secret = parts[1]
-	} else {
-		s.logger.Debug("Assuming Bearer auth type for Authorization header with no type specified")
-		authType = "Bearer"
-		secret = authorization
+// headerForwardingRoundTripper sets the captured forwarded headers on every
+// outgoing request before delegating to the next RoundTripper.
+type headerForwardingRoundTripper struct {
+	headers http.Header
+	next    http.RoundTripper
+}
+
+func (h *headerForwardingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	for name, values := range h.headers {
+		req.Header.Del(name)
+		for _, value := range values {
+			req.Header.Add(name, value)
+		}
+	}
+	return h.next.RoundTrip(req)
+}
+
+// createClientWithAuth creates a new API client with the given Authorization
+// header and/or additional forwarded headers.
+func (s *ServerContainer) createClientWithAuth(authorization string, forwarded http.Header) (promv1.API, http.RoundTripper) {
+	rt := s.defaultRT
+	if len(forwarded) > 0 {
+		rt = &headerForwardingRoundTripper{headers: forwarded, next: rt}
 	}
 
-	rt := config.NewAuthorizationCredentialsRoundTripper(authType, config.NewInlineSecret(secret), s.defaultRT)
+	if authorization != "" {
+		var authType, secret string
+		if strings.Contains(authorization, " ") {
+			parts := strings.SplitN(authorization, " ", 2)
+			authType = parts[0]
+			secret = parts[1]
+		} else {
+			s.logger.Debug("Assuming Bearer auth type for Authorization header with no type specified")
+			authType = "Bearer"
+			secret = authorization
+		}
+
+		rt = config.NewAuthorizationCredentialsRoundTripper(authType, config.NewInlineSecret(secret), rt)
+	}
+
 	client, err := mcpProm.NewAPIClient(s.prometheusURL, rt)
 	if err != nil {
 		s.logger.Error("Failed to create API client with credentials", "err", err)


### PR DESCRIPTION
## What

Adds a repeatable `--web.forward-headers` flag (HTTP transport) naming additional incoming MCP request headers to forward to the Prometheus API, alongside the always-forwarded `Authorization` header.

## Why

#44 made the HTTP transport forward each caller's `Authorization` header, enabling per-caller credentials. Multi-tenant Prometheus-compatible backends (Cortex, Mimir, Thanos) additionally key tenancy off request headers such as `X-Scope-OrgID` — today those are dropped at the MCP server, so admin/cross-tenant callers behind such backends can't select a tenant per request even though the backend supports it. This came up deploying this server against a multi-tenant Mimir: tenant-realm bearer tokens work great via #44, but tokens that require an explicit `X-Scope-OrgID` (e.g. admin identities) cannot be used through a shared instance.

Related context: #13 (inbound security stays external, so header semantics are the backend's concern) and #76 (client-selectable routing via a header — this flag is a conservative building block for that).

## How

- `authContextMiddleware` captures the configured headers (multi-value preserved) into the request context next to `Authorization`.
- `GetAPIClient` builds a per-request client when auth *or* forwarded headers are present; a small `headerForwardingRoundTripper` chains under the existing `NewAuthorizationCredentialsRoundTripper`.
- Requests carrying none of the forwarded headers keep using the default `--http.config` client — behavior is unchanged unless the flag is set.
- `NewStreamableHTTPHandler` gains a **variadic** `forwardHeaders` parameter, so existing callers are source-compatible.

## Testing

- New middleware table tests (configured / unconfigured / multi-value / none-configured), context round-trip tests, and full-flow tests against a mock Prometheus asserting `X-Scope-OrgID` arrives with auth, without auth, and that the default client sends neither — mirroring the existing patterns in `middleware_test.go`.
- `go test ./...`, `go vet`, `gofmt` all clean.
- Exercised end-to-end against a multi-tenant Mimir behind an OIDC gateway: forwarded `X-Scope-OrgID` + admin bearer selects the tenant per request; tenant tokens without the header keep working as before.

## Docs

README gains a "Per-Request Header Forwarding" section (also documenting the existing #44 Authorization forwarding, which wasn't mentioned yet) and the new flag in the help-output block.