### PR TITLE
feat(web): add /-/healthy and /-/ready health endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,17 @@ Use the `--web.config.file` command-line flag to provide an HTTP configuration f
 Please see [Flags](#command-line-flags) for more information.
 
 ## Telemetry
+### Health Endpoints
+
+The web server exposes health endpoints on the configured listen address, following the `/-/healthy` and `/-/ready` convention used across the Prometheus ecosystem:
+
+| Endpoint | Description |
+| --- | --- |
+| `/-/healthy` | Liveness: always returns `200 OK` while the process is up and serving HTTP. |
+| `/-/ready` | Readiness: returns `200 OK` once the MCP transport is mounted and able to accept client sessions, and `503 Service Unavailable` before that and during shutdown. |
+
+These map directly onto Kubernetes liveness/readiness probes. The `prom_mcp_server_ready` metric reports the same readiness state.
+
 ### Metrics
 
 Once running, the server exposes Prometheus metrics on the configured listen address and telemetry path (`:8080/metrics`, by default).

--- a/cmd/prometheus-mcp/main.go
+++ b/cmd/prometheus-mcp/main.go
@@ -228,7 +228,7 @@ func main() {
 		rootCtxCancel()
 		os.Exit(1) //nolint:gocritic
 	}
-	srv := initHTTPServer(logger)
+	srv := initHTTPServer(logger, mcpContainer)
 
 	var g run.Group
 	{
@@ -289,6 +289,7 @@ func main() {
 				case "stdio":
 					logger.Debug("starting MCP server", "transport", "stdio")
 
+					mcpContainer.SetReady(true)
 					if err := mcpServer.Run(ctx, &sdkmcp.StdioTransport{}); err != nil {
 						return fmt.Errorf("MCP server failed: %w", err)
 					}
@@ -298,6 +299,7 @@ func main() {
 
 					httpMcpHandler := mcp.NewStreamableHTTPHandler(mcpServer, logger, *flagMcpSessionTimeout)
 					http.Handle("/mcp", httpMcpHandler)
+					mcpContainer.SetReady(true)
 					<-cancel
 				default:
 					return fmt.Errorf("unsupported transport type: %s", *flagMcpTransport)
@@ -306,6 +308,7 @@ func main() {
 				return nil
 			},
 			func(err error) {
+				mcpContainer.SetReady(false)
 				close(cancel)
 				rootCtxCancel()
 			},
@@ -352,7 +355,7 @@ func main() {
 	logger.Info("See you next time!")
 }
 
-func initHTTPServer(logger *slog.Logger) *http.Server {
+func initHTTPServer(logger *slog.Logger, mcpContainer *mcp.ServerContainer) *http.Server {
 	server := &http.Server{
 		// These are TCP-level timeouts for individual HTTP
 		// request/response cycles, not MCP session timeouts.  MCP
@@ -380,6 +383,8 @@ func initHTTPServer(logger *slog.Logger) *http.Server {
 		metrics.Registry, metricsHandler,
 	)
 	http.Handle("/metrics", metricsHandler)
+	http.Handle("/-/healthy", mcpContainer.HandleHealthy())
+	http.Handle("/-/ready", mcpContainer.HandleReady())
 
 	landingPageLinks := []web.LandingLinks{
 		{

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kevinburke/ssh_config v1.6.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mdlayher/socket v0.6.1 // indirect
 	github.com/mdlayher/vsock v1.3.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/pkg/mcp/handlers_test.go
+++ b/pkg/mcp/handlers_test.go
@@ -22,6 +22,7 @@ import (
 	"io/fs"
 	"log/slog"
 	"net/http"
+	"net/http/httptest"
 	"strings"
 	"sync"
 	"testing"
@@ -30,6 +31,7 @@ import (
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/require"
 
@@ -3776,4 +3778,50 @@ func TestSeriesHandlerSpecialCharactersInMatchers(t *testing.T) {
 			require.Equal(t, tc.matcher, capturedMatcher)
 		})
 	}
+}
+
+// Health endpoint tests. These intentionally do not run in parallel: SetReady
+// writes the shared package-level server ready gauge.
+
+func TestSetReady(t *testing.T) {
+	s := &ServerContainer{}
+
+	require.False(t, s.Ready())
+
+	s.SetReady(true)
+	require.True(t, s.Ready())
+	require.InDelta(t, 1, testutil.ToFloat64(metricServerReady), 0)
+
+	s.SetReady(false)
+	require.False(t, s.Ready())
+	require.InDelta(t, 0, testutil.ToFloat64(metricServerReady), 0)
+}
+
+func TestHandleHealthy(t *testing.T) {
+	s := &ServerContainer{}
+
+	rec := httptest.NewRecorder()
+	s.HandleHealthy().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/-/healthy", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "Healthy")
+}
+
+func TestHandleReady(t *testing.T) {
+	s := &ServerContainer{}
+
+	rec := httptest.NewRecorder()
+	s.HandleReady().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/-/ready", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
+	require.Contains(t, rec.Body.String(), "Not Ready")
+
+	s.SetReady(true)
+	rec = httptest.NewRecorder()
+	s.HandleReady().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/-/ready", nil))
+	require.Equal(t, http.StatusOK, rec.Code)
+	require.Contains(t, rec.Body.String(), "Ready")
+
+	s.SetReady(false)
+	rec = httptest.NewRecorder()
+	s.HandleReady().ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/-/ready", nil))
+	require.Equal(t, http.StatusServiceUnavailable, rec.Code)
 }

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -58,7 +58,7 @@ func telemetryMiddleware(logger *slog.Logger) mcp.Middleware {
 }
 
 // telemetryHandleInitialize handles the MCP initialization, logging client
-// info and setting the server ready metric after successful initialization.
+// info after successful initialization.
 func telemetryHandleInitialize(ctx context.Context, method string, req mcp.Request, next mcp.MethodHandler, logger *slog.Logger) (mcp.Result, error) {
 	params, ok := req.GetParams().(*mcp.InitializeParams)
 	if !ok {
@@ -96,8 +96,6 @@ func telemetryHandleInitialize(ctx context.Context, method string, req mcp.Reque
 		"server_name", serverName,
 		"server_version", serverVersion,
 	)
-
-	metricServerReady.Set(1)
 
 	return result, nil
 }

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/alpkeskin/gotoon"
@@ -308,6 +309,10 @@ type ServerContainer struct {
 	// Docs state management.
 	docsMu sync.RWMutex
 	docs   *docsState
+
+	// Readiness state, flipped by SetReady once the MCP transport is able
+	// to accept client sessions.
+	ready atomic.Bool
 }
 
 // newServerContainer creates a new ServerContainer with the given configuration.
@@ -414,6 +419,47 @@ func (s *ServerContainer) GetEffectiveTruncationLimit(perCallLimit int) int {
 
 	// Otherwise, return global truncation limit.
 	return s.truncationLimit
+}
+
+// SetReady records whether the MCP server is ready to accept client sessions,
+// i.e. the configured transport is serving. It drives both the `/-/ready` web
+// endpoint and the server ready metric, keeping the two signals consistent.
+func (s *ServerContainer) SetReady(ready bool) {
+	s.ready.Store(ready)
+	if ready {
+		metricServerReady.Set(1)
+		return
+	}
+	metricServerReady.Set(0)
+}
+
+// Ready reports whether the MCP server is ready to accept client sessions.
+func (s *ServerContainer) Ready() bool {
+	return s.ready.Load()
+}
+
+// HandleHealthy serves liveness probes. It always succeeds: if the web server
+// can serve the request, the process is alive.
+func (s *ServerContainer) HandleHealthy() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "Prometheus MCP Server is Healthy.")
+	})
+}
+
+// HandleReady serves readiness probes, failing with a 503 until the MCP
+// transport is able to accept client sessions.
+func (s *ServerContainer) HandleReady() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !s.Ready() {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			fmt.Fprintln(w, "Prometheus MCP Server is Not Ready.")
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "Prometheus MCP Server is Ready.")
+	})
 }
 
 // Docs search methods


### PR DESCRIPTION
Expose liveness and readiness endpoints on the web server, following
the /-/healthy and /-/ready convention used across the Prometheus
ecosystem, so deployments can wire them to health probes.

/-/healthy always returns 200 while the process is serving HTTP.

/-/ready returns 200 once the MCP transport is able to accept client
sessions (flipped in both the stdio and http transport paths), and 503
before that and during shutdown so probes drain traffic on graceful
stop.

The `prom_mcp_server_ready` metric is now driven by the same readiness
state instead of being set on the first client initialize request.

The old behavior was buggy anyway, since it declared/claimed that it was
testing the server's readiness, but in reality it only got set on first
client connection. That's both inaccurate and creates a chicken-or-egg
scenario for LB type deployments.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
