### PR TITLE
fix(web): serve metrics on the --web.telemetry-path flag, not `/metrics`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
 # Changelog
 
 ## Unreleased
+
+* [BUGFIX] web: serve metrics on the path given by `--web.telemetry-path` instead of hardcoding `/metrics`, custom telemetry paths no longer 404.

--- a/cmd/prometheus-mcp/main.go
+++ b/cmd/prometheus-mcp/main.go
@@ -382,7 +382,7 @@ func initHTTPServer(logger *slog.Logger, mcpContainer *mcp.ServerContainer) *htt
 	metricsHandler = promhttp.InstrumentMetricHandler(
 		metrics.Registry, metricsHandler,
 	)
-	http.Handle("/metrics", metricsHandler)
+	http.Handle(*flagWebTelemetryPath, metricsHandler)
 	http.Handle("/-/healthy", mcpContainer.HandleHealthy())
 	http.Handle("/-/ready", mcpContainer.HandleReady())
 


### PR DESCRIPTION
Metrics handler was previously registered on literal `/metrics`, which
left all of the flag wiring invalid.

Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
