### PR TITLE
fix(mcp): surface tool failure details in middleware error logs

### DIFF
--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // MCP method names. Needed because the go-sdk does not export them.
@@ -112,7 +111,6 @@ func telemetryHandleToolCall(ctx context.Context, method string, req mcp.Request
 
 	toolName := params.Name
 	args := params.Arguments
-	labels := prometheus.Labels{"tool_name": toolName}
 	logger = logger.With("tool_name", toolName, "request_arguments", args)
 
 	logger.Debug("Calling tool")
@@ -120,7 +118,7 @@ func telemetryHandleToolCall(ctx context.Context, method string, req mcp.Request
 	result, err := next(ctx, method, req)
 	duration := time.Since(startTime)
 
-	metricToolCallDuration.With(labels).Observe(duration.Seconds())
+	metricToolCallDuration.WithLabelValues(toolName).Observe(duration.Seconds())
 	logger.Debug("Finished calling tool", "duration", duration)
 
 	// Protocol level failure; this is an unknown tool, a handler returning
@@ -128,21 +126,21 @@ func telemetryHandleToolCall(ctx context.Context, method string, req mcp.Request
 	// typed nil, which passes the type assertion below, so need to check
 	// the error first.
 	if err != nil {
-		metricToolCallsFailed.With(labels).Inc()
+		metricToolCallsFailed.WithLabelValues(toolName).Inc()
 		logger.Error("Failed calling tool", "error_kind", "protocol", "error", err)
 		return result, err
 	}
 
 	toolResult, ok := result.(*mcp.CallToolResult)
 	if !ok || toolResult == nil {
-		metricToolCallsFailed.With(labels).Inc()
+		metricToolCallsFailed.WithLabelValues(toolName).Inc()
 		logger.Error("Unusable tool call result", "error_kind", "unusable_result", "result_type", fmt.Sprintf("%T", result))
 		return result, nil
 	}
 
 	// Tool level failures.
 	if toolResult.IsError {
-		metricToolCallsFailed.With(labels).Inc()
+		metricToolCallsFailed.WithLabelValues(toolName).Inc()
 		logger.Error("Failed calling tool", "error_kind", "tool_result", "error", toolResultErrorText(toolResult))
 	}
 
@@ -184,11 +182,11 @@ func telemetryHandlePromptGet(ctx context.Context, method string, req mcp.Reques
 	result, err := next(ctx, method, req)
 	duration := time.Since(startTime)
 
-	metricPromptGetDuration.With(prometheus.Labels{"prompt_name": promptName}).Observe(duration.Seconds())
+	metricPromptGetDuration.WithLabelValues(promptName).Observe(duration.Seconds())
 	logger.Debug("Finished calling prompt", "duration", duration)
 
 	if err != nil {
-		metricPromptGetsFailed.With(prometheus.Labels{"prompt_name": promptName}).Inc()
+		metricPromptGetsFailed.WithLabelValues(promptName).Inc()
 		logger.Error("Failed calling prompt", "error", err)
 	}
 
@@ -280,11 +278,11 @@ func telemetryHandleResourceRead(ctx context.Context, method string, req mcp.Req
 	result, err := next(ctx, method, req)
 	duration := time.Since(startTime)
 
-	metricResourceCallDuration.With(prometheus.Labels{"resource_uri": uri}).Observe(duration.Seconds())
+	metricResourceCallDuration.WithLabelValues(uri).Observe(duration.Seconds())
 	logger.Debug("Finished calling resource", "duration", duration)
 
 	if err != nil {
-		metricResourceCallsFailed.With(prometheus.Labels{"resource_uri": uri}).Inc()
+		metricResourceCallsFailed.WithLabelValues(uri).Inc()
 		logger.Error("Failed calling resource", "error", err)
 	}
 

--- a/pkg/mcp/middleware.go
+++ b/pkg/mcp/middleware.go
@@ -15,6 +15,7 @@ package mcp
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"time"
 
@@ -84,7 +85,7 @@ func telemetryHandleInitialize(ctx context.Context, method string, req mcp.Reque
 	// Extract server info from result for logging.
 	serverName := ""
 	serverVersion := ""
-	if initResult, ok := result.(*mcp.InitializeResult); ok && initResult.ServerInfo != nil {
+	if initResult, ok := result.(*mcp.InitializeResult); ok && initResult != nil && initResult.ServerInfo != nil {
 		serverName = initResult.ServerInfo.Name
 		serverVersion = initResult.ServerInfo.Version
 	}
@@ -111,6 +112,7 @@ func telemetryHandleToolCall(ctx context.Context, method string, req mcp.Request
 
 	toolName := params.Name
 	args := params.Arguments
+	labels := prometheus.Labels{"tool_name": toolName}
 	logger = logger.With("tool_name", toolName, "request_arguments", args)
 
 	logger.Debug("Calling tool")
@@ -118,20 +120,50 @@ func telemetryHandleToolCall(ctx context.Context, method string, req mcp.Request
 	result, err := next(ctx, method, req)
 	duration := time.Since(startTime)
 
-	metricToolCallDuration.With(prometheus.Labels{"tool_name": toolName}).Observe(duration.Seconds())
+	metricToolCallDuration.With(labels).Observe(duration.Seconds())
 	logger.Debug("Finished calling tool", "duration", duration)
-	toolResult, ok := result.(*mcp.CallToolResult)
-	if !ok {
-		metricToolCallsFailed.With(prometheus.Labels{"tool_name": toolName}).Inc()
-		logger.Error("Failed to convert result to call tool result")
+
+	// Protocol level failure; this is an unknown tool, a handler returning
+	// *jsonrpc.Error, or an output marshalling failure. This results in a
+	// typed nil, which passes the type assertion below, so need to check
+	// the error first.
+	if err != nil {
+		metricToolCallsFailed.With(labels).Inc()
+		logger.Error("Failed calling tool", "error_kind", "protocol", "error", err)
 		return result, err
 	}
-	if err != nil || toolResult.IsError {
-		metricToolCallsFailed.With(prometheus.Labels{"tool_name": toolName}).Inc()
-		logger.Error("Failed calling tool", "result", result, "error", err)
+
+	toolResult, ok := result.(*mcp.CallToolResult)
+	if !ok || toolResult == nil {
+		metricToolCallsFailed.With(labels).Inc()
+		logger.Error("Unusable tool call result", "error_kind", "unusable_result", "result_type", fmt.Sprintf("%T", result))
+		return result, nil
 	}
 
-	return result, err
+	// Tool level failures.
+	if toolResult.IsError {
+		metricToolCallsFailed.With(labels).Inc()
+		logger.Error("Failed calling tool", "error_kind", "tool_result", "error", toolResultErrorText(toolResult))
+	}
+
+	return result, nil
+}
+
+// toolResultErrorText returns the error message from a failed tool call
+// result. Spec says it should be put in first non-empty text content entry.
+func toolResultErrorText(res *mcp.CallToolResult) string {
+	// Check if error was recorded via SetError
+	if err := res.GetError(); err != nil {
+		return err.Error()
+	}
+
+	for _, content := range res.Content {
+		if tc, ok := content.(*mcp.TextContent); ok && tc != nil && tc.Text != "" {
+			return tc.Text
+		}
+	}
+
+	return "tool reported an error with no message"
 }
 
 // telemetryHandlePromptGet instruments a prompts/get request with metrics and logging.
@@ -157,7 +189,7 @@ func telemetryHandlePromptGet(ctx context.Context, method string, req mcp.Reques
 
 	if err != nil {
 		metricPromptGetsFailed.With(prometheus.Labels{"prompt_name": promptName}).Inc()
-		logger.Error("Failed calling prompt", "result", result, "error", err)
+		logger.Error("Failed calling prompt", "error", err)
 	}
 
 	return result, err
@@ -173,14 +205,14 @@ func telemetryHandlePromptList(ctx context.Context, method string, req mcp.Reque
 	duration := time.Since(startTime)
 
 	metricPromptListDuration.Observe(duration.Seconds())
-	if listResult, ok := result.(*mcp.ListPromptsResult); ok {
+	if listResult, ok := result.(*mcp.ListPromptsResult); ok && listResult != nil {
 		logger = logger.With("prompt_count", len(listResult.Prompts))
 	}
 	logger.Debug("Finished listing prompts", "duration", duration)
 
 	if err != nil {
 		metricPromptListsFailed.Inc()
-		logger.Error("Failed listing prompts", "result", result, "error", err)
+		logger.Error("Failed listing prompts", "error", err)
 	}
 
 	return result, err
@@ -253,7 +285,7 @@ func telemetryHandleResourceRead(ctx context.Context, method string, req mcp.Req
 
 	if err != nil {
 		metricResourceCallsFailed.With(prometheus.Labels{"resource_uri": uri}).Inc()
-		logger.Error("Failed calling resource", "result", result, "error", err)
+		logger.Error("Failed calling resource", "error", err)
 	}
 
 	return result, err

--- a/pkg/mcp/middleware_test.go
+++ b/pkg/mcp/middleware_test.go
@@ -327,9 +327,10 @@ func TestTelemetryHandleToolCall(t *testing.T) {
 			nextResult: &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: "error"}},
 			},
-			nextErr:    errors.New("tool boom"),
-			wantLogged: "Failed calling tool",
-			wantErr:    true,
+			nextErr:       errors.New("tool boom"),
+			wantLogged:    "Failed calling tool",
+			wantLogFields: []string{`"error_kind":"protocol"`},
+			wantErr:       true,
 		},
 		{
 			name: "failed type assertion on result returns early without panic",
@@ -338,10 +339,11 @@ func TestTelemetryHandleToolCall(t *testing.T) {
 				Arguments: json.RawMessage(`{}`),
 			}),
 			// Return a non-CallToolResult to trigger failed type assertion.
-			nextResult: &mcp.InitializeResult{ProtocolVersion: "2025-03-26"},
-			nextErr:    nil,
-			wantLogged: "Failed to convert result to call tool result",
-			wantErr:    false,
+			nextResult:    &mcp.InitializeResult{ProtocolVersion: "2025-03-26"},
+			nextErr:       nil,
+			wantLogged:    "Unusable tool call result",
+			wantLogFields: []string{`"error_kind":"unusable_result"`},
+			wantErr:       false,
 		},
 		{
 			name: "nil result from next returns early without panic",
@@ -349,12 +351,13 @@ func TestTelemetryHandleToolCall(t *testing.T) {
 				Name:      "query",
 				Arguments: json.RawMessage(`{}`),
 			}),
-			// Return nil result with an error to trigger failed type
-			// assertion on nil interface value.
-			nextResult: nil,
-			nextErr:    errors.New("nil result boom"),
-			wantLogged: "Failed to convert result to call tool result",
-			wantErr:    true,
+			// Return nil result with an error; the error must be handled
+			// before the result is ever type asserted.
+			nextResult:    nil,
+			nextErr:       errors.New("nil result boom"),
+			wantLogged:    "Failed calling tool",
+			wantLogFields: []string{`"error_kind":"protocol"`},
+			wantErr:       true,
 		},
 		{
 			name: "tool result with IsError true logs failure",
@@ -366,9 +369,10 @@ func TestTelemetryHandleToolCall(t *testing.T) {
 				Content: []mcp.Content{&mcp.TextContent{Text: "something went wrong"}},
 				IsError: true,
 			},
-			nextErr:    nil,
-			wantLogged: "Failed calling tool",
-			wantErr:    false,
+			nextErr:       nil,
+			wantLogged:    "Failed calling tool",
+			wantLogFields: []string{`"error_kind":"tool_result"`, "something went wrong"},
+			wantErr:       false,
 		},
 		{
 			name:       "invalid params type falls through gracefully",


### PR DESCRIPTION
Failed tool calls logged an unreadable result dump alongside an error
field that was structurally always empty:

Noticed this error while testing things a ways back:

```
msg="Failed calling tool" tool_name=build_info result="&{Meta:map[] Content:[0xc1f82610040] ... IsError:true err:<nil>}" error=<nil>
```

MCP spec says a tool level failure is reported to client inside the
result, so we need to format/extract the result. Spec puts tool errors
in the first content item, so we take that as the result field.

Also fixes some ordering issues with regards to checking results to
properly check go errors first before handling type assertion code and
checking for typed nil values.

The typed nil check on the prompts/list result is a real crash fix, not
tidying: when a client sends a garbage `cursor`, the go-sdk returns a
typed nil `*mcp.ListPromptsResult` alongside `ErrInvalidParams`. The old
code asserted it and read `.Prompts` without checking, and nothing in
the SDK recovers panics, so a single bad request from any client took
the whole server down.

Updates the tool call middleware tests for the new log messages.

Assisted-by: Claude Code:claude-fable-5-1 <noreply@anthropic.com>
Signed-off-by: TJ Hoplock <t.hoplock@gmail.com>
